### PR TITLE
Fix body forwarding for unparsed requests

### DIFF
--- a/lib/modes/mock.js
+++ b/lib/modes/mock.js
@@ -14,11 +14,11 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
   function delayResponse(path, prism, req, res) {
     var scheduleResponse = responseDelay.delayTimeInMs(prism.config.delay);
     setTimeout(function() {
-      writeHttpResponse(path, res);
       if (scheduleResponse > 0) {
         logger.verboseLog('Mock response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
       }
       logger.verboseLog('Dispatching request ' + req.url + ' from ' + path);
+      writeHttpResponse(path, res);
       logger.logSuccess('Mocked', req, prism);
     }, scheduleResponse);
   }
@@ -140,7 +140,7 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
       });
     }
 
-    prismUtils.getBody(req, function() {
+    prismUtils.getBody(req, res, function() {
       handleMockRequest(req, res, prism);
     });
   };

--- a/lib/modes/mockrecord.js
+++ b/lib/modes/mockrecord.js
@@ -24,7 +24,7 @@ function MockRecord(prismUtils, mockFilenameGenerator, mock, proxy) {
     }
 
     if (prism.config.hashFullRequest) {
-      prismUtils.getBody(req, function() {
+      prismUtils.getBody(req, res, function() {
         handleMockRecordRequest(req, res, prism)
       });
     } else {

--- a/lib/modes/proxy.js
+++ b/lib/modes/proxy.js
@@ -7,20 +7,6 @@ var ResponseDelay = require('../services/response-delay');
 
 function Proxy(logger, prismUtils, responseDelay) {
   function proxyResponse(req, res, prism) {
-
-    if (req.bodyRead) {
-      //re-stream the request body, because it has already been consumed
-      req.removeAllListeners('data');
-      req.removeAllListeners('end');
-
-      process.nextTick(function() {
-        if (req.body) {
-          req.emit('data', new Buffer(req.body))
-        }
-        req.emit('end')
-      });
-    }
-
     prism.server.web(req, res);
     logger.logSuccess('Proxied', req, prism);
   }
@@ -38,7 +24,7 @@ function Proxy(logger, prismUtils, responseDelay) {
     }
 
     if (prism.config.hashFullRequest(prism.config, req)) {
-      prismUtils.getBody(req, function() {
+      prismUtils.getBody(req, res, function() {
         handleProxyRequest(req, res, prism);
       });
     } else {

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -164,6 +164,14 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
         res.end(JSON.stringify(json));
       });
 
+      proxyServer.on('proxyReq', function(proxyReq, req, res, options) {
+        if (req.body) {
+          // if req.body is set, it means the request stream has been
+          // consumed, and we have to write the proxy request manually
+          proxyReq.write(req.body);
+        }
+      });
+
       if (_.includes(['record', 'mockrecord'], config.mode)) {
         config.responseHandler = getResponseHandler(config).handleResponse;
         proxyServer.on('proxyRes', httpEvents.handleResponse);

--- a/lib/services/api.js
+++ b/lib/services/api.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var director = require('director');
+var bodyParser = require('body-parser');
 var pjson = require('../../package.json');
 
 var ClearMocks = require('./clear-mocks');
@@ -32,27 +33,32 @@ function Api(prismManager, prism, prismUtils, mock, clearMocks) {
     router.post(route + '/override/:name/clear', overrideClear);
   };
 
+  this.bodyParser = prismUtils.chainMiddlewares([
+    bodyParser.urlencoded({ extended: true }),
+    bodyParser.json(),
+    function(req, res, next) {
+      if (_.isEqual(req.body, {})) delete req.body;
+      next();
+    }
+  ]);
+
   // Handle an api request to /_prism
   this.handleRequest = function(req, res, next) {
     if(!req.url.startsWith(route)) {
       return false;
     }
-    prismUtils.getBody(req, function(body) {
-      // director should parse JSON for me!
-      // https://github.com/flatiron/director/issues/275
-      try {
-        req.body = JSON.parse(body);
-      } catch (err) {}
+    this.bodyParser(req, res, function() {
+      router.dispatch(req, res
+        /* *** Can't handle error and close response if this isn't a valid request, function(err) {
+        if (err) {
+          console.log('api returning 404');
+          res.writeHead(404);
+          res.end();
+        }
+      }*/
+      );
     });
-    return router.dispatch(req, res
-      /* *** Can't handle error and close response if this isn't a valid request, function(err) {
-      if (err) {
-        console.log('api returning 404');
-        res.writeHead(404);
-        res.end();
-      }
-    }*/
-    );
+    return true;
   };
 
   function version() {

--- a/lib/services/logger.js
+++ b/lib/services/logger.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var winston = require('winston');
 
 var PrismUtils = require('./prism-utils');
@@ -14,8 +15,9 @@ function Logger(prismUtils) {
     })]
   });
 
-  this.useVerboseLog = function() {
-    logger.transports.console.level = 'verbose';
+  this.useVerboseLog = function(useVerbose) {
+    useVerbose = _.isUndefined(useVerbose) ? true : useVerbose;
+    logger.transports.console.level = useVerbose ? 'verbose' : 'info';
   };
 
   this.logSuccess = function(modeMsg, req, prism) {

--- a/lib/services/prism-utils.js
+++ b/lib/services/prism-utils.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
+var bodyParser = require('body-parser');
 
 function PrismUtils() {
   this.isValidMode = function(mode) {
@@ -65,33 +66,19 @@ function PrismUtils() {
     return urlPath;
   };
 
+  this.bodyParser = bodyParser.raw({ type: '*/*' });
+
   /**
    * Get the body of the request so that we can use it to hash a response.
-   *
-   * NOTE: I'm getting the request body here so that we can reference it in the
-   * response when creating a hash.  is there a better way to do this?
-   * issue on node-http-proxy tracker: 
-   * https://github.com/nodejitsu/node-http-proxy/issues/667
    */
-  this.getBody = function(req, bodyCallback) {
-    if (req.bodyRead) {
+  this.getBody = function(req, res, bodyCallback) {
+    if (req.body) {
       bodyCallback(req.body);
     } else {
-      var buffer = '';
-      req.on('data', function(data) {
-        buffer += data;
-
-        // Too much POST data, kill the connection!
-        if (buffer.length > 1e6) {
-          req.connection.destroy();
-        }
-      });
-      req.on('end', function() {
-        req.body = buffer;
-        req.bodyRead = true;
-        if (bodyCallback) {
-          bodyCallback(buffer);
-        }
+      this.bodyParser(req, res, function() {
+        // body-parser sets req.body to {} when there is no body
+        if (_.isEqual(req.body, {})) delete req.body;
+        bodyCallback(req.body);
       });
     }
   };
@@ -100,7 +87,7 @@ function PrismUtils() {
    * File helpers stolen from Grunt
    */
   var pathSeparatorRe = /[\/\\]/g;
-   
+
   function exists() {
     var filepath = path.join.apply(path, arguments);
     return fs.existsSync(filepath);
@@ -130,9 +117,31 @@ function PrismUtils() {
     }, '');
   }
 
+  function chainMiddlewares(middlewares) {
+    if (_.toArray(middlewares).length === 0) {
+      return function(req, res, next) { next(); }
+    } else {
+      return function(req, res, next) {
+        function chain(middlewares) {
+          if (middlewares.length > 0) {
+            return function() {
+              middlewares[0](req, res, chain(middlewares.slice(1)));
+            }
+          } else {
+            return function() {
+              next();
+            }
+          }
+        }
+        chain(middlewares)(req, res, next);
+      }
+    }
+  }
+
   this.exists = exists;
   this.isDir = isDir;
   this.mkdir = mkdir;
+  this.chainMiddlewares = chainMiddlewares;
 }
 
 module.exports = PrismUtils;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "body-parser": "^1.15.2",
     "compression": "^1.6.2",
     "connect": "^3.5.0",
     "express": "^4.14.0",
@@ -43,6 +42,7 @@
     "querystring": "^0.2.0"
   },
   "dependencies": {
+    "body-parser": "^1.18.2",
     "director": "^1.2.8",
     "forwarded-for": "^1.0.0",
     "http-proxy": "^1.13.1",

--- a/test/integration/api-spec.js
+++ b/test/integration/api-spec.js
@@ -105,7 +105,7 @@ describe('api', function() {
           "data": "an overidden server response"
         }
       });
-      httpPost('/_prism/override/overrideCreateTest/create', postData).then(function(res) {
+      httpPost('/_prism/override/overrideCreateTest/create', postData, 'application/json').then(function(res) {
         assert.equal(res.body, 'OK');
         return httpGet('/test');
       }).then(function(res) {
@@ -129,7 +129,7 @@ describe('api', function() {
         "url": "/test",
         "body": ""
       });
-      httpPost('/_prism/override/overrideRemoveTest/remove', postData).then(function(res) {
+      httpPost('/_prism/override/overrideRemoveTest/remove', postData, 'application/json').then(function(res) {
         assert.equal(res.body, 'OK');
         return httpGet('/test');
       }).then(function(res) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -82,15 +82,15 @@ exports.deleteMocks = function(paths) {
   });
 };
 
-exports.httpPost = function(path, body) {
-  return exports.httpCall('POST', path, body);
+exports.httpPost = function(path, body, contentType) {
+  return exports.httpCall('POST', path, body, contentType);
 };
 
-exports.httpGet = function(path, body) {
-  return exports.httpCall('GET', path, body);
+exports.httpGet = function(path, body, contentType) {
+  return exports.httpCall('GET', path, body, contentType);
 };
 
-exports.httpCall = function(method, path, body) {
+exports.httpCall = function(method, path, body, contentType) {
   var deferred = q.defer();
   var options = {
     host: 'localhost',
@@ -109,7 +109,7 @@ exports.httpCall = function(method, path, body) {
 
   if (body) {
     options.headers = {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': contentType || 'application/x-www-form-urlencoded',
       'Content-Length': body.length
     };
     req = http.request(options, cb);


### PR DESCRIPTION
Use `body-parser` to read the request body into a buffer when requested.
This avoids corrupting binary payloads.